### PR TITLE
feat(widget): add exit confirmation dialog with double Ctrl+C trigger

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,4 +62,4 @@ pub use pane::{
     PaneHandle, PaneId, PaneSize, PaneState, ScreenCell, ScreenColor, ScreenSnapshot, SpawnConfig,
 };
 pub use pty::PaneEvent;
-pub use widget::{CockpitWidget, PaneWidget};
+pub use widget::{CockpitWidget, ConfirmDialog, DialogButton, DialogState, PaneWidget};


### PR DESCRIPTION
## Summary

- Add `ConfirmDialog` widget with `DialogButton` and `DialogState` types
- Implement double Ctrl+C detection (500ms window) to trigger exit dialog
- Support keyboard input (y/n, Enter, arrow keys) and mouse clicking

## Changes

- `src/widget.rs`: Added dialog widget components
- `src/lib.rs`: Exported new types
- `examples/basic.rs`: Integrated dialog into event loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)