### PR TITLE
chore(lint): enable clippy::unwrap_used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,5 @@ tokio = { version = "1", features = ["full"] }
 unsafe_code = "forbid"
 
 [lints.clippy]
-pedantic = { level = "warn" }
+pedantic = { level = "warn", priority = -1 }
+unwrap_used = "deny"


### PR DESCRIPTION
## Summary
- Enables `clippy::unwrap_used` at `deny` level in `[lints.clippy]`, so any `.unwrap()` call fails clippy/CI.
- Sets explicit `priority = -1` on the existing `pedantic` group entry (Cargo requires a priority when a lint group and an individual lint share a table, otherwise `clippy::lint_groups_priority` errors).
- No source changes needed — the crate already has **zero** `.unwrap()` calls in `src/`, `examples/`, or tests, so this is a pure guard against future regressions.

Closes #3

## Test plan
- [x] `cargo build --all-targets` — passes
- [x] `cargo clippy --all-targets --all-features` — 0 errors (only pre-existing `pedantic` warnings, unrelated to this change)
- [x] `cargo test` — 5 unit tests + 1 doctest pass

---
This pull request was opened by the Clippy lint improvements → issue + PR (Rust repos) → Slack routine of moadim.